### PR TITLE
Follow-up to #393. Move server JAR properties to server POM

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2021 Oracle and/or its affiliates and others.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates and others.
     All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -82,8 +82,6 @@
         <!-- Make sure the two versions are in sync with the maven version -->
         <spec.version>2.1</spec.version>
         <bundle.version>2.1.0-SNAPSHOT</bundle.version>
-        <extensionName>jakarta.websocket</extensionName>
-        <bundle.symbolicName>jakarta.websocket-api</bundle.symbolicName>
         <vendorName>Eclipse Foundation</vendorName>
     </properties>
 

--- a/api/server/pom.xml
+++ b/api/server/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2021 Oracle and/or its affiliates and others.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates and others.
     All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -31,6 +31,11 @@
     <name>Jakarta WebSocket - Server API</name>
     <description>Jakarta WebSocket - Server API</description>
     <url>https://projects.eclipse.org/projects/ee4j.websocket</url>
+
+    <properties>
+        <bundle.symbolicName>jakarta.websocket-api</bundle.symbolicName>
+        <extensionName>jakarta.websocket</extensionName>
+    </properties>
 
     <build>
         <resources>


### PR DESCRIPTION
Better to specify server JAR specific properties in the server POM
rather than in the parent POM.