### PR TITLE
Update version to 2.2 and year to 2022 for next development cycle.

### DIFF
--- a/api/client/pom.xml
+++ b/api/client/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>jakarta.websocket</groupId>
         <artifactId>jakarta.websocket-all</artifactId>
-        <version>2.1.0-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jakarta.websocket-client-api</artifactId>

--- a/api/client/src/main/javadoc/doc-files/EFSL.html
+++ b/api/client/src/main/javadoc/doc-files/EFSL.html
@@ -41,10 +41,10 @@
 
 <p>The notice is:</p>
 
-<p>&quot;Copyright &copy; 2018, 2020 Eclipse Foundation. This software or
+<p>&quot;Copyright &copy; 2018, 2022 Eclipse Foundation. This software or
   document includes material copied from or derived from
   Jakarta ® WebSocket
-  https://jakarta.ee/specifications/websocket/2.1/&quot;</p>
+  https://jakarta.ee/specifications/websocket/2.2/&quot;</p>
 
 <h2>Disclaimers</h2>
 

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -30,7 +30,7 @@
 
     <groupId>jakarta.websocket</groupId>
     <artifactId>jakarta.websocket-all</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Jakarta WebSocket API Parent</name>
@@ -80,7 +80,7 @@
 
     <properties>
         <!-- Make sure the spec version is in sync with the maven version -->
-        <spec.version>2.1</spec.version>
+        <spec.version>2.2</spec.version>
         <bundle.version>${project.version}</bundle.version>
         <vendorName>Eclipse Foundation</vendorName>
     </properties>
@@ -225,7 +225,7 @@
                             <header><![CDATA[Jakarta WebSocket API v${project.version}]]></header>
                             <bottom><![CDATA[
 Comments to: <a href="mailto:websocket-dev@eclipse.org">websocket-dev@eclipse.org</a>.<br>
-Copyright &#169; 2018, 2021 Eclipse Foundation. All rights reserved.<br>
+Copyright &#169; 2018, 2022 Eclipse Foundation. All rights reserved.<br>
 Use is subject to <a href="{@docRoot}/doc-files/EFSL.html" target="_top">license terms</a>.]]>
                             </bottom>
                             <docfilessubdirs>true</docfilessubdirs>

--- a/api/server/pom.xml
+++ b/api/server/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>jakarta.websocket</groupId>
         <artifactId>jakarta.websocket-all</artifactId>
-        <version>2.1.0-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jakarta.websocket-api</artifactId>

--- a/api/server/src/main/javadoc/doc-files/EFSL.html
+++ b/api/server/src/main/javadoc/doc-files/EFSL.html
@@ -41,10 +41,10 @@
 
 <p>The notice is:</p>
 
-<p>&quot;Copyright &copy; 2018, 2020 Eclipse Foundation. This software or
+<p>&quot;Copyright &copy; 2018, 2022 Eclipse Foundation. This software or
   document includes material copied from or derived from
   Jakarta ® WebSocket
-  https://jakarta.ee/specifications/websocket/2.1/&quot;</p>
+  https://jakarta.ee/specifications/websocket/2.2/&quot;</p>
 
 <h2>Disclaimers</h2>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2019, 2021 Contributors to the Eclipse Foundation
+    Copyright (c) 2019, 2022 Contributors to the Eclipse Foundation
     All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -29,7 +29,7 @@
 
     <groupId>jakarta.websocket</groupId>
     <artifactId>websocket-parent</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Jakarta WebSocket</name>

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2019, 2021 Contributors to the Eclipse Foundation.
+    Copyright (c) 2019, 2022 Contributors to the Eclipse Foundation.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -28,7 +28,7 @@
 
     <groupId>jakarta.websocket</groupId>
     <artifactId>websocket-spec</artifactId>
-    <version>2.1-SNAPSHOT</version>
+    <version>2.2-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Jakarta WebSocket Specification</name>

--- a/spec/src/main/asciidoc/WebSocket.adoc
+++ b/spec/src/main/asciidoc/WebSocket.adoc
@@ -1,8 +1,8 @@
 :xrefstyle: short
 :sectnums!:
-== Jakarta WebSocket Specification, Version 2.1
+== Jakarta WebSocket Specification, Version 2.2
 
-Copyright (c) 2011, 2021 Oracle and/or its affiliates and others.
+Copyright (c) 2011, 2022 Oracle and/or its affiliates and others.
 All rights reserved.
 
 Eclipse is a registered trademark of the Eclipse Foundation. Jakarta
@@ -1500,6 +1500,10 @@ either to the *GOLD_MEMBER* or *PLATINUM_MEMBER* roles.
 
 This appendix lists the changes in the WebSocket specification.
 This appendix is non-normative.
+
+=== Changes Between 2.2 and 2.1
+
+* TBD
 
 === Changes Between 2.1 and 2.0
 

--- a/spec/src/main/asciidoc/license-efsl.adoc
+++ b/spec/src/main/asciidoc/license-efsl.adoc
@@ -52,10 +52,10 @@ specification is expressly prohibited.
 
 The notice is:
 
-"Copyright © 2018, 2020 Eclipse Foundation. This software or document
+"Copyright © 2018, 2022 Eclipse Foundation. This software or document
 includes material copied from or derived from
 Jakarta ® WebSocket
-https://jakarta.ee/specifications/websocket/2.1/[https://jakarta.ee/specifications/websocket/2.1/]"
+https://jakarta.ee/specifications/websocket/2.2/[https://jakarta.ee/specifications/websocket/2.2/]"
 
 ==== Disclaimers
 


### PR DESCRIPTION
It isn't clear at this point if the next release will be 2.2 or 3.0 so start with 2.2 and we can always change it to 3.0 later if required.