### PR TITLE
Update Endpoint.java

### DIFF
--- a/api/client/src/main/java/jakarta/websocket/Endpoint.java
+++ b/api/client/src/main/java/jakarta/websocket/Endpoint.java
@@ -49,15 +49,14 @@ package jakarta.websocket;
  * <code>
  * public class EchoServer extends Endpoint {
  *
+ *     @Override
  *     public void onOpen(Session session, EndpointConfig config) {
- *         final RemoteEndpoint remote = session.getBasicRemote();
- *         session.addMessageHandler(String.class, new MessageHandler.Whole&lt;String&lt;() {
- *             public void onMessage(String text) {
- *                 try {
- *                     remote.sendString("Got your message (" + text + "). Thanks !");
- *                 } catch (IOException ioe) {
- *                     // handle send failure here
- *                 }
+ *         final RemoteEndpoint.Basic remote = session.getBasicRemote();
+ *         session.addMessageHandler(String.class, (String text) -> {
+ *             try {
+ *                remote.sendText("Got your message (" + text + "). Thanks !");
+ *             } catch (IOException ioe) {
+ *                 // handle send failure here
  *             }
  *         });
  *     }


### PR DESCRIPTION
Trivial fixes to javadoc example.

As written, the example won't compile (the second `&lt;` needs to be `&gt;`, and `RemoteEndpoint` doesn't have a `sendString()` method.)