### PR TITLE
fix a minor typo in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,4 +36,4 @@ To make changes, fork this repository, make your changes, and submit a pull requ
 
 ## About Jakarta WebSocket
 
-Jakarta WebSocket defines defines a set of Java APIs for the development of WebSocket applications.
+Jakarta WebSocket defines a set of Java APIs for the development of WebSocket applications.


### PR DESCRIPTION
The word 'defines' was typed twice in a row within the readme file.