### PR TITLE
Fix #417 - Also call ClientEndPoint.Configurator.afterResponse(HandshakeResponse) on failed handshakes

### DIFF
--- a/api/client/src/main/java/jakarta/websocket/ClientEndpointConfig.java
+++ b/api/client/src/main/java/jakarta/websocket/ClientEndpointConfig.java
@@ -108,7 +108,9 @@ public interface ClientEndpointConfig extends EndpointConfig {
         /**
          * This method is called by the implementation after it has received a handshake response from the server as a
          * result of a handshake interaction it initiated. The developer may implement this method in order to inspect
-         * the returning handshake response.
+         * the returning handshake response. This method is called after both a successful and unsuccessful handshake.
+         * For a failed handshake, depending on the how the handshake fails, an HTTP response may not be received and in
+         * that case the {@link HandshakeResponse} will contain an empty header map.
          *
          * @param hr the handshake response sent by the server.
          */

--- a/spec/src/main/asciidoc/WebSocket.adoc
+++ b/spec/src/main/asciidoc/WebSocket.adoc
@@ -1529,6 +1529,10 @@ This appendix is non-normative.
 Add the `X509Certificate[] getUserX509CertificateChain()` method to `HandshakeRequest` so the client certificate chain,
 if present, is available during the WebSocket handshake.
 
+* https://github.com/jakartaee/websocket/issues/417[Issue 417]
+Clarify that `ClientEndPoint.Configurator.afterResponse(HandshakeResponse)` is to be called after both successful and
+unsuccessful WebSocket handshakes.
+
 === Changes Between 2.2 and 2.1
 
 * https://github.com/jakartaee/websocket/issues/176[Issue 176]

--- a/tck/spec-tests/src/main/java/com/sun/ts/tests/websocket/ee/jakarta/websocket/handshakeresponse/WSCClientIT.java
+++ b/tck/spec-tests/src/main/java/com/sun/ts/tests/websocket/ee/jakarta/websocket/handshakeresponse/WSCClientIT.java
@@ -41,76 +41,76 @@ import jakarta.websocket.ClientEndpointConfig;
 @ExtendWith(ArquillianExtension.class)
 public class WSCClientIT extends WebSocketCommonClient {
 
-	private static final long serialVersionUID = 2315071335485201973L;
+    private static final long serialVersionUID = 2315071335485201973L;
 
-	@Deployment(testable = false)
-	public static WebArchive createDeployment() throws IOException {
+    @Deployment(testable = false)
+    public static WebArchive createDeployment() throws IOException {
 
-		WebArchive archive = ShrinkWrap.create(WebArchive.class, "wsc_ee_jakarta_websocket_handshakeresponse_web.war");
-		archive.addPackages(true, Filters.exclude(WSCClientIT.class),
-				"com.sun.ts.tests.websocket.ee.jakarta.websocket.handshakeresponse");
-		archive.addClasses(IOUtil.class);
-		return archive;
-	};
+        WebArchive archive = ShrinkWrap.create(WebArchive.class, "wsc_ee_jakarta_websocket_handshakeresponse_web.war");
+        archive.addPackages(true, Filters.exclude(WSCClientIT.class),
+                "com.sun.ts.tests.websocket.ee.jakarta.websocket.handshakeresponse");
+        archive.addClasses(IOUtil.class);
+        return archive;
+    };
 
-	public WSCClientIT() throws Exception {
-		setContextRoot("wsc_ee_jakarta_websocket_handshakeresponse_web");
-	}
+    public WSCClientIT() throws Exception {
+        setContextRoot("wsc_ee_jakarta_websocket_handshakeresponse_web");
+    }
 
-	static final String KEY = "aFirstKey";
+    static final String KEY = "aFirstKey";
 
-	static final String[] HEADERS = { "header1", "header2", "header3", "header4", "header5", "header6", "header7",
-			"header8" };
+    static final String[] HEADERS = { "header1", "header2", "header3", "header4", "header5", "header6", "header7",
+            "header8" };
 
-	/* Run test */
+    /* Run test */
 
-	/*
-	 * @testName: headerToHeaderTest
-	 * 
-	 * @assertion_ids: WebSocket:JAVADOC:77; WebSocket:JAVADOC:174;
-	 * WebSocket:JAVADOC:15; WebSocket:JAVADOC:16; WebSocket:JAVADOC:210;
-	 * 
-	 * @test_Strategy: HandshakeResponse.getHeaders HandshakeRequest.getHeaders
-	 * ClientEndpointConfig.Configurator.afterResponse
-	 * ClientEndpointConfig.Configurator.beforeRequest
-	 * ServerEndpointConfig.Configurator.modifyHandshake
-	 * 
-	 * This test sets headers to request on client, on server it reads them, and put
-	 * them to response, and headers are checked on client
-	 */
-	@Test
-	public void headerToHeaderTest() throws Exception {
-		ClientConfigurator configurator = new ClientConfigurator();
-		configurator.addToRequestAndResponse(KEY, HEADERS);
-		ClientEndpointConfig config = ClientEndpointConfig.Builder.create().configurator(configurator).build();
-		setClientEndpointConfig(config);
-		invoke("echo", "anything", "anything");
-		configurator.assertBeforeRequestHasBeenCalled();
-		configurator.assertAfterResponseHasBeenCalled();
-	}
+    /*
+     * @testName: headerToHeaderTest
+     *
+     * @assertion_ids: WebSocket:JAVADOC:77; WebSocket:JAVADOC:174;
+     * WebSocket:JAVADOC:15; WebSocket:JAVADOC:16; WebSocket:JAVADOC:210;
+     *
+     * @test_Strategy: HandshakeResponse.getHeaders HandshakeRequest.getHeaders
+     * ClientEndpointConfig.Configurator.afterResponse
+     * ClientEndpointConfig.Configurator.beforeRequest
+     * ServerEndpointConfig.Configurator.modifyHandshake
+     *
+     * This test sets headers to request on client, on server it reads them, and put
+     * them to response, and headers are checked on client
+     */
+    @Test
+    public void headerToHeaderTest() throws Exception {
+        ClientConfigurator configurator = new ClientConfigurator();
+        configurator.addToRequestAndResponse(KEY, HEADERS);
+        ClientEndpointConfig config = ClientEndpointConfig.Builder.create().configurator(configurator).build();
+        setClientEndpointConfig(config);
+        invoke("echo", "anything", "anything");
+        configurator.assertBeforeRequestHasBeenCalled();
+        configurator.assertAfterResponseHasBeenCalled();
+    }
 
-	/*
-	 * @testName: addHeadersOnServerTest
-	 * 
-	 * @assertion_ids: WebSocket:JAVADOC:77; WebSocket:JAVADOC:174;
-	 * WebSocket:JAVADOC:15; WebSocket:JAVADOC:16; WebSocket:JAVADOC:210;
-	 * 
-	 * @test_Strategy: HandshakeResponse.getHeaders HandshakeRequest.getHeaders
-	 * ClientEndpointConfig.Configurator.afterResponse
-	 * ClientEndpointConfig.Configurator.beforeRequest
-	 * ServerEndpointConfig.Configurator.modifyHandshake
-	 * 
-	 * This test puts new values to header map on server and it is checked on a
-	 * client
-	 */
-	@Test
-	public void addHeadersOnServerTest() throws Exception {
-		ClientConfigurator configurator = new ClientConfigurator();
-		configurator.addToResponse(SetHeadersConfigurator.KEY, SetHeadersConfigurator.HEADERS);
-		ClientEndpointConfig config = ClientEndpointConfig.Builder.create().configurator(configurator).build();
-		setClientEndpointConfig(config);
-		invoke("setheaders", "anything", "anything");
-		configurator.assertBeforeRequestHasBeenCalled();
-		configurator.assertAfterResponseHasBeenCalled();
-	}
+    /*
+     * @testName: addHeadersOnServerTest
+     *
+     * @assertion_ids: WebSocket:JAVADOC:77; WebSocket:JAVADOC:174;
+     * WebSocket:JAVADOC:15; WebSocket:JAVADOC:16; WebSocket:JAVADOC:210;
+     *
+     * @test_Strategy: HandshakeResponse.getHeaders HandshakeRequest.getHeaders
+     * ClientEndpointConfig.Configurator.afterResponse
+     * ClientEndpointConfig.Configurator.beforeRequest
+     * ServerEndpointConfig.Configurator.modifyHandshake
+     *
+     * This test puts new values to header map on server and it is checked on a
+     * client
+     */
+    @Test
+    public void addHeadersOnServerTest() throws Exception {
+        ClientConfigurator configurator = new ClientConfigurator();
+        configurator.addToResponse(SetHeadersConfigurator.KEY, SetHeadersConfigurator.HEADERS);
+        ClientEndpointConfig config = ClientEndpointConfig.Builder.create().configurator(configurator).build();
+        setClientEndpointConfig(config);
+        invoke("setheaders", "anything", "anything");
+        configurator.assertBeforeRequestHasBeenCalled();
+        configurator.assertAfterResponseHasBeenCalled();
+    }
 }

--- a/tck/spec-tests/src/main/java/com/sun/ts/tests/websocket/ee/jakarta/websocket/handshakeresponse/WSCClientIT.java
+++ b/tck/spec-tests/src/main/java/com/sun/ts/tests/websocket/ee/jakarta/websocket/handshakeresponse/WSCClientIT.java
@@ -17,8 +17,6 @@
 
 package com.sun.ts.tests.websocket.ee.jakarta.websocket.handshakeresponse;
 
-import java.io.IOException;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Filters;
@@ -45,7 +43,7 @@ import jakarta.websocket.DeploymentException;
 public class WSCClientIT extends WebSocketCommonClient {
 
     @Deployment(testable = false)
-    public static WebArchive createDeployment() throws IOException {
+    public static WebArchive createDeployment() {
 
         WebArchive archive = ShrinkWrap.create(WebArchive.class, "wsc_ee_jakarta_websocket_handshakeresponse_web.war");
         archive.addPackages(true, Filters.exclude(WSCClientIT.class),

--- a/tck/spec-tests/src/main/java/com/sun/ts/tests/websocket/ee/jakarta/websocket/handshakeresponse/WSCClientIT.java
+++ b/tck/spec-tests/src/main/java/com/sun/ts/tests/websocket/ee/jakarta/websocket/handshakeresponse/WSCClientIT.java
@@ -54,7 +54,7 @@ public class WSCClientIT extends WebSocketCommonClient {
                 "com.sun.ts.tests.websocket.ee.jakarta.websocket.handshakeresponse");
         archive.addClasses(IOUtil.class);
         return archive;
-    };
+    }
 
     public WSCClientIT() throws Exception {
         setContextRoot("wsc_ee_jakarta_websocket_handshakeresponse_web");

--- a/tck/spec-tests/src/main/java/com/sun/ts/tests/websocket/ee/jakarta/websocket/handshakeresponse/WSCClientIT.java
+++ b/tck/spec-tests/src/main/java/com/sun/ts/tests/websocket/ee/jakarta/websocket/handshakeresponse/WSCClientIT.java
@@ -24,6 +24,8 @@ import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Filters;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -32,6 +34,7 @@ import com.sun.ts.tests.websocket.common.impl.ClientConfigurator;
 import com.sun.ts.tests.websocket.common.util.IOUtil;
 
 import jakarta.websocket.ClientEndpointConfig;
+import jakarta.websocket.DeploymentException;
 
 /*
  * @class.setup_props: webServerHost;
@@ -110,6 +113,25 @@ public class WSCClientIT extends WebSocketCommonClient {
         ClientEndpointConfig config = ClientEndpointConfig.Builder.create().configurator(configurator).build();
         setClientEndpointConfig(config);
         invoke("setheaders", "anything", "anything");
+        configurator.assertBeforeRequestHasBeenCalled();
+        configurator.assertAfterResponseHasBeenCalled();
+    }
+
+
+    @Test
+    public void failedConnectionTest() throws Exception {
+        ClientConfigurator configurator = new ClientConfigurator();
+        ClientEndpointConfig config = ClientEndpointConfig.Builder.create().configurator(configurator).build();
+        setClientEndpointConfig(config);
+        DeploymentException expectedFailure = null;
+        try {
+            invoke("doesNotExist", "anything", "anything");
+        } catch (Exception e) {
+            if (e.getCause() instanceof DeploymentException) {
+                expectedFailure = (DeploymentException) e.getCause();
+            }
+        }
+        Assertions.assertNotNull(expectedFailure, "WebSocket request to nonexistent endpoint did not fail");
         configurator.assertBeforeRequestHasBeenCalled();
         configurator.assertAfterResponseHasBeenCalled();
     }

--- a/tck/spec-tests/src/main/java/com/sun/ts/tests/websocket/ee/jakarta/websocket/handshakeresponse/WSCClientIT.java
+++ b/tck/spec-tests/src/main/java/com/sun/ts/tests/websocket/ee/jakarta/websocket/handshakeresponse/WSCClientIT.java
@@ -44,8 +44,6 @@ import jakarta.websocket.DeploymentException;
 @ExtendWith(ArquillianExtension.class)
 public class WSCClientIT extends WebSocketCommonClient {
 
-    private static final long serialVersionUID = 2315071335485201973L;
-
     @Deployment(testable = false)
     public static WebArchive createDeployment() throws IOException {
 


### PR DESCRIPTION
Fix #417 

The PR updates the Javadoc for `.Configurator.afterResponse(HandshakeResponse) ` adds a new TCK test and updates the specification change log.

There are also some clean-ups to the files touched by this PR in separate commits.